### PR TITLE
fix onevnet provider for context variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ Create a ONE Vnet
         netmask         => '255.255.0.0',
         network_address => '10.0.2.0',
         context         => {
-           SEARCH_DOMAIN       => 'your.domain',
-           SECURITY_GROUPS     => '0',
-           FILTER_IP_SPOOFING  => 'YES',
-           FILTER_MAC_SPOOFING => 'YES',
+           search_domain       => 'your.domain',
+           security_groups     => '0',
+           filter_ip_spoofing  => 'YES',
+           filter_mac_spoofing => 'YES',
         },
     }
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ Create a ONE Vnet
         vlanid          => '1550',
         netmask         => '255.255.0.0',
         network_address => '10.0.2.0',
+        context         => {
+           SEARCH_DOMAIN       => 'your.domain',
+           SECURITY_GROUPS     => '0',
+           FILTER_IP_SPOOFING  => 'YES',
+           FILTER_MAC_SPOOFING => 'YES',
+        },
     }
 
 

--- a/lib/puppet/provider/onevnet/cli.rb
+++ b/lib/puppet/provider/onevnet/cli.rb
@@ -108,6 +108,7 @@ Puppet::Type.type(:onevnet).provide(:cli) do
           when :netmask
             ['NETWORK_MASK', v]
           when :context
+            # do nothing here, see below
           else
             [k.to_s.upcase, v]
         end

--- a/lib/puppet/provider/onevnet/cli.rb
+++ b/lib/puppet/provider/onevnet/cli.rb
@@ -75,7 +75,7 @@ Puppet::Type.type(:onevnet).provide(:cli) do
           :phydev   => vnet.xpath('./PHYDEV').text,
           :vlanid   => vnet.xpath('./VLAN_ID').text,
           :context         => ( Hash[ vnet.xpath('./TEMPLATE').children.collect { |c|
-                                  [c.name.to_s.upcase, c.text] unless parameter_names.include?(c.name.upcase)
+                                  [c.name.to_s.downcase, c.text] unless parameter_names.include?(c.name.upcase)
                                 }.reject{ |c| c.nil? } ] unless vnet.xpath('./TEMPLATE').nil? ),
           :dnsservers      => (vnet.xpath('./TEMPLATE/DNS').text.split(' ') unless vnet.xpath('./TEMPLATE/DNS').nil?),
           :gateway         => (vnet.xpath('./TEMPLATE/GATEWAY').text unless vnet.xpath('./TEMPLATE/GATEWAY').nil?),

--- a/lib/puppet/provider/onevnet/cli.rb
+++ b/lib/puppet/provider/onevnet/cli.rb
@@ -47,7 +47,8 @@ Puppet::Type.type(:onevnet).provide(:cli) do
     file.close
     self.debug "Adding new network using template: #{tempfile}"
     onevnet('create', file.path)
-    file.delete
+    self.debug "new network temp file path: #{file.path}"
+    #file.delete
     @property_hash[:ensure] = :present
   end
 
@@ -112,6 +113,7 @@ Puppet::Type.type(:onevnet).provide(:cli) do
     file.close
     self.debug(IO.read file.path)
     onevnet('update', resource[:name], file.path, '--append') unless @property_hash.empty?
-    file.delete
+    self.debug "updating network from file path: #{file.path}"
+    #file.delete
   end
 end

--- a/lib/puppet/provider/onevnet/cli.rb
+++ b/lib/puppet/provider/onevnet/cli.rb
@@ -115,6 +115,7 @@ Puppet::Type.type(:onevnet).provide(:cli) do
       end
     }.map { |a| "#{a[0]} = #{a[1]}" unless a.nil? }.join("\n")
     unless @property_hash[:context].nil? or @property_hash[:context].to_s.empty?
+      file << "\n"
       file << @property_hash[:context].map{ |k,v|
         [k.to_s.upcase, v]
       }.map { |a| "#{a[0]} = #{a[1]}" unless a.nil? }.join("\n")

--- a/lib/puppet/provider/onevnet/cli.rb
+++ b/lib/puppet/provider/onevnet/cli.rb
@@ -75,7 +75,7 @@ Puppet::Type.type(:onevnet).provide(:cli) do
           :phydev   => vnet.xpath('./PHYDEV').text,
           :vlanid   => vnet.xpath('./VLAN_ID').text,
           :context         => ( Hash[ vnet.xpath('./TEMPLATE').children.collect { |c|
-                                  [c.name.to_s.downcase, c.text] unless parameter_names.include?(c.name.upcase)
+                                  [c.name.downcase, c.text] unless parameter_names.include?(c.name.upcase)
                                 }.reject{ |c| c.nil? } ] unless vnet.xpath('./TEMPLATE').nil? ),
           :dnsservers      => (vnet.xpath('./TEMPLATE/DNS').text.split(' ') unless vnet.xpath('./TEMPLATE/DNS').nil?),
           :gateway         => (vnet.xpath('./TEMPLATE/GATEWAY').text unless vnet.xpath('./TEMPLATE/GATEWAY').nil?),

--- a/lib/puppet/provider/onevnet/cli.rb
+++ b/lib/puppet/provider/onevnet/cli.rb
@@ -64,6 +64,7 @@ Puppet::Type.type(:onevnet).provide(:cli) do
 
   # Return the full hash of all existing onevnet resources
   def self.instances
+    parameter_names = ['NAME', 'VN_MAD', 'BRIDGE', 'PHYDEV', 'VLAN_ID', 'DNS', 'GATEWAY', 'NETWORK_MASK', 'NETWORK_ADDRESS', 'MTU', 'TEXT']
     vnets = Nokogiri::XML(onevnet('list', '-x')).root.xpath('/VNET_POOL/VNET')
     vnets.collect do |vnet|
       new(
@@ -73,7 +74,9 @@ Puppet::Type.type(:onevnet).provide(:cli) do
           :bridge   => vnet.xpath('./BRIDGE').text,
           :phydev   => vnet.xpath('./PHYDEV').text,
           :vlanid   => vnet.xpath('./VLAN_ID').text,
-          :context  => ( Hash[vnet.xpath('./TEMPLATE').children.collect do |c|  [c.name.to_s.upcase, c.text] unless ['NAME', 'VN_MAD', 'BRIDGE', 'PHYDEV', 'VLAN_ID', 'DNS', 'GATEWAY', 'NETWORK_MASK', 'NETWORK_ADDRESS', 'MTU', 'TEXT'].include?(c.name.upcase)  end.reject{ |c| c.nil?}] unless vnet.xpath('./TEMPLATE').nil? ),
+          :context         => ( Hash[ vnet.xpath('./TEMPLATE').children.collect { |c|
+                                  [c.name.to_s.upcase, c.text] unless parameter_names.include?(c.name.upcase)
+                                }.reject{ |c| c.nil? } ] unless vnet.xpath('./TEMPLATE').nil? ),
           :dnsservers      => (vnet.xpath('./TEMPLATE/DNS').text.split(' ') unless vnet.xpath('./TEMPLATE/DNS').nil?),
           :gateway         => (vnet.xpath('./TEMPLATE/GATEWAY').text unless vnet.xpath('./TEMPLATE/GATEWAY').nil?),
           :netmask         => (vnet.xpath('./TEMPLATE/NETWORK_MASK').text unless vnet.xpath('./TEMPLATE/NETWORK_MASK').nil?),

--- a/lib/puppet/provider/onevnet/cli.rb
+++ b/lib/puppet/provider/onevnet/cli.rb
@@ -74,7 +74,7 @@ Puppet::Type.type(:onevnet).provide(:cli) do
           :bridge   => vnet.xpath('./BRIDGE').text,
           :phydev   => vnet.xpath('./PHYDEV').text,
           :vlanid   => vnet.xpath('./VLAN_ID').text,
-          :context  => nil,
+          :context  => ( Hash[vnet.xpath('./TEMPLATE').children.collect do |c|  [c.name.to_s.upcase, c.text] unless ['NAME', 'VN_MAD', 'BRIDGE', 'PHYDEV', 'VLAN_ID', 'DNS', 'GATEWAY', 'NETWORK_MASK', 'NETWORK_ADDRESS', 'MTU', 'TEXT'].include?(c.name.upcase)  end.reject{ |c| c.nil?}] unless vnet.xpath('./TEMPLATE').nil? ),
           :dnsservers      => (vnet.xpath('./TEMPLATE/DNS').text.split(' ') unless vnet.xpath('./TEMPLATE/DNS').nil?),
           :gateway         => (vnet.xpath('./TEMPLATE/GATEWAY').text unless vnet.xpath('./TEMPLATE/GATEWAY').nil?),
           :netmask         => (vnet.xpath('./TEMPLATE/NETWORK_MASK').text unless vnet.xpath('./TEMPLATE/NETWORK_MASK').nil?),

--- a/lib/puppet/provider/onevnet/cli.rb
+++ b/lib/puppet/provider/onevnet/cli.rb
@@ -105,11 +105,17 @@ Puppet::Type.type(:onevnet).provide(:cli) do
             ['DNS', "\"#{v.join(' ')}\""]
           when :netmask
             ['NETWORK_MASK', v]
+          when :context
           else
             [k.to_s.upcase, v]
         end
       end
     }.map { |a| "#{a[0]} = #{a[1]}" unless a.nil? }.join("\n")
+    unless @property_hash[:context].nil? or @property_hash[:context].to_s.empty?
+      file << @property_hash[:context].map{ |k,v|
+        [k.to_s.upcase, v]
+      }.map { |a| "#{a[0]} = #{a[1]}" unless a.nil? }.join("\n")
+    end
     file.close
     self.debug(IO.read file.path)
     onevnet('update', resource[:name], file.path, '--append') unless @property_hash.empty?

--- a/lib/puppet/provider/onevnet/cli.rb
+++ b/lib/puppet/provider/onevnet/cli.rb
@@ -47,8 +47,7 @@ Puppet::Type.type(:onevnet).provide(:cli) do
     file.close
     self.debug "Adding new network using template: #{tempfile}"
     onevnet('create', file.path)
-    self.debug "new network temp file path: #{file.path}"
-    #file.delete
+    file.delete
     @property_hash[:ensure] = :present
   end
 
@@ -119,7 +118,6 @@ Puppet::Type.type(:onevnet).provide(:cli) do
     file.close
     self.debug(IO.read file.path)
     onevnet('update', resource[:name], file.path, '--append') unless @property_hash.empty?
-    self.debug "updating network from file path: #{file.path}"
-    #file.delete
+    file.delete
   end
 end

--- a/spec/acceptance/onevnet_spec.rb
+++ b/spec/acceptance/onevnet_spec.rb
@@ -85,6 +85,55 @@ describe 'onevnet type' do
     end
   end
 
+  describe 'when creating a vnet with context variables' do
+    it 'should idempotently run' do
+      pp =<<-eos
+      onevnet { 'vnet4':
+          ensure          => present,
+          bridge          => 'basebr0',
+          phydev          => 'br0',
+          dnsservers      => ['8.8.8.8', '4.4.4.4'],
+          gateway         => '10.0.2.1',
+          vlanid          => '1550',
+          netmask         => '255.255.0.0',
+          network_address => '10.0.2.0',
+          context         => {
+              security_groups    => '0',
+              search_domain      => 'my.domain',
+              filter_ip_spoofing => 'yes',
+          },
+      }
+      eos
+
+      apply_manifest(pp, :catch_failures => true)
+    end
+  end
+
+  describe 'when updating a vnet with context variables' do
+    it 'should idempotently run' do
+      pp =<<-eos
+      onevnet { 'vnet4':
+          ensure          => present,
+          bridge          => 'basebr0',
+          phydev          => 'br0',
+          dnsservers      => ['8.8.8.8', '4.4.4.4'],
+          gateway         => '10.0.2.1',
+          vlanid          => '1550',
+          netmask         => '255.255.0.0',
+          network_address => '10.0.2.0',
+          context         => {
+              security_groups     => '0',
+              search_domain       => 'my.domain',
+              filter_ip_spoofing  => 'yes',
+              filter_mac_spoofing => 'yes',
+          },
+      }
+      eos
+
+      apply_manifest(pp, :catch_failures => true)
+    end
+  end
+
   describe 'when updating a fixed vnet' do
     it 'should idempotently run' do
       pp =<<-EOS
@@ -114,6 +163,9 @@ describe 'onevnet type' do
           ensure => absent,
         }
         onevnet { 'vnet3':
+          ensure => absent,
+        }
+        onevnet { 'vnet4':
           ensure => absent,
         }
       EOS


### PR DESCRIPTION
This fixes the onevnet provider for context variables - previously context variables were only correctly set on initial creation of the vnet, not subsequent updates or subsequent puppet runs, as the onevnet provider attempted to update the vnet with an invalid temporary template file containing, for example:

```
CONTEXT = {"search_domain"=>"my.domain", "filter_ip_spoofing"=>"YES", "filter_mac_spoofing"=>"YES"...
```

Note the context is written as a stringified hash, not as KEY="value" on separate lines - it should be like this:

```
SEARCH_DOMAIN="my.domain"
FILTER_IP_SPOOFING="YES"
FILTER_MAC_SPOOFING="YES"
...
```

This PR fixes the onevnet provider to properly handle a hash of extra variables passed in via the context parameter on the onevnet type. Note, the provider just updates values - it does not remove any extra values already present on the vnet, so as to not break any existing configuration that has been manually set in OpenNebula.