### PR TITLE
WIP: Onecluster purge vnets option

### DIFF
--- a/lib/puppet/provider/onecluster/cli.rb
+++ b/lib/puppet/provider/onecluster/cli.rb
@@ -116,8 +116,10 @@ Puppet::Type.type(:onecluster).provide(:cli) do
   end
   def vnets=(value)
     vnets = @property_hash[:vnets] || []
-    (vnets - value).each do |vnet|
-      onecluster('delvnet', resource[:name], vnet)
+    if @property_hash[:purge_vnets]
+      (vnets - value).each do |vnet|
+        onecluster('delvnet', resource[:name], vnet)
+      end
     end
     (value - vnets).each do |vnet|
       onecluster('addvnet', resource[:name], vnet)

--- a/lib/puppet/type/onecluster.rb
+++ b/lib/puppet/type/onecluster.rb
@@ -40,6 +40,12 @@ Puppet::Type.newtype(:onecluster) do
     end
   end
 
+  newproperty(:purge_vnets, :boolean => true) do
+    desc "should extraneous Virtual Networks in the cluster be removed - default true"
+    defaultto :true
+    newvalues(:true, :false)
+  end
+
   newproperty(:datastores, :array_matching => :all) do
     desc "Datastores to add to the cluster - optional"
     defaultto []

--- a/spec/provider/onecluster_spec.rb
+++ b/spec/provider/onecluster_spec.rb
@@ -36,6 +36,11 @@ describe provider_class do
         skip('needs test to verify removal')
       end
   end
+  context 'when deleting with purge_vnets => false' do
+      it 'should not run onevnet delete <name>' do
+        skip('needs test to verify does not remove extraneous vnets')
+      end
+  end
   context 'when updating' do
       skip('update needs all tests')
   end


### PR DESCRIPTION
This allows to not purge extraneous vnets on a onecluster - useful if allowing users to create their own vnets in addition to the administrator-managed ones. If using purge_vnets => false the admin will need to remove vnets manually. (Default for purge_vnets is true to maintain the old behavior).