### PR TITLE
novnc service should respect ha_setup flag

### DIFF
--- a/manifests/oned/sunstone/service.pp
+++ b/manifests/oned/sunstone/service.pp
@@ -16,8 +16,9 @@
 #
 class one::oned::sunstone::service (
   $sunstone_passenger = $one::sunstone_passenger,
-  $sunstone_novnc     = $one::sunstone_novnc
-) {
+  $sunstone_novnc     = $one::sunstone_novnc,
+  $ha_setup           = $one::ha_setup,
+){
   if $sunstone_passenger {
     $srv_ensure = stopped
     $srv_enable = false
@@ -25,17 +26,26 @@ class one::oned::sunstone::service (
     $srv_ensure = running
     $srv_enable = true
   }
-  $_sunstone_novnc_ensure = $sunstone_novnc ? {
-    true    => running,
-    default => stopped,
-  }
+
   service { 'opennebula-sunstone':
     ensure  => $srv_ensure,
     enable  => $srv_enable,
     require => Service['opennebula'],
   }
+
+  if ($ha_setup) {
+    $_sunstone_novnc_enable = false
+    $_sunstone_novnc_ensure = undef
+  } else {
+    $_sunstone_novnc_enable = $sunstone_novnc
+    $_sunstone_novnc_ensure = $sunstone_novnc ? {
+      true    => running,
+      default => stopped,
+    }
+  }
+
   service { 'opennebula-novnc':
     ensure => $_sunstone_novnc_ensure,
-    enable => $sunstone_novnc,
+    enable => $_sunstone_novnc_enable,
   }
 }

--- a/manifests/oned/sunstone/service.pp
+++ b/manifests/oned/sunstone/service.pp
@@ -22,6 +22,9 @@ class one::oned::sunstone::service (
   if $sunstone_passenger {
     $srv_ensure = stopped
     $srv_enable = false
+  } elsif ($ha_setup) {
+    $srv_ensure = undef
+    $srv_enable = false
   } else {
     $srv_ensure = running
     $srv_enable = true


### PR DESCRIPTION
This configures novnc service to be `enabled: false` and `ensure: undef` if using ha_setup (as it should be to be managed with pacemaker). If not using ha_setup the behavior is as before.

This also configures sunstone service to respect ha_setup, for the case of using sunstone service itself not passenger (sunstone service is already correctly setup to be stopped&not enabled if using passenger).